### PR TITLE
Speculative update of WAO height details

### DIFF
--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -3099,9 +3099,11 @@
       "height": ["10m"],
       "height_name": ["10magl"],
       "height_station_masl": 17.0,
-      "latitude": 52.95042,
-      "long_name": "Weybourne Observatory, UK",
-      "longitude": 1.12194
+      "latitude": 52.95,
+      "long_name": "WAO",
+      "longitude": 1.121,
+      "reference": "https://meta.icos-cp.eu/resources/stations/AS_WAO",
+      "comments": "05/01/2023: Station elevation of 31m may be included within ICOS header but value above of 17m is more recently agreed upon value and should be correct."
     },
     "UCAM": {
       "height": ["10m"],

--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -3096,25 +3096,25 @@
   },
   "WAO": {
     "ICOS": {
-      "height": ["21m"],
-      "height_name": ["20magl"],
-      "height_station_masl": 10.0,
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 21.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
       "longitude": 1.12194
     },
     "UCAM": {
-      "height": ["21m"],
-      "height_name": ["20magl"],
-      "height_station_masl": 10.0,
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 21.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
       "longitude": 1.12194
     },
     "UEA": {
-      "height": ["21m"],
-      "height_name": ["20magl"],
-      "height_station_masl": 10.0,
+      "height": ["10m"],
+      "height_name": ["10magl"],
+      "height_station_masl": 21.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
       "longitude": 1.12194

--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -3097,7 +3097,7 @@
   "WAO": {
     "ICOS": {
       "height": ["10m"],
-      "height_name": ["10magl"],
+      "height_name": ["20magl"],
       "height_station_masl": 17.0,
       "latitude": 52.95,
       "long_name": "WAO",
@@ -3107,7 +3107,7 @@
     },
     "UCAM": {
       "height": ["10m"],
-      "height_name": ["10magl"],
+      "height_name": ["20magl"],
       "height_station_masl": 17.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
@@ -3115,7 +3115,7 @@
     },
     "UEA": {
       "height": ["10m"],
-      "height_name": ["10magl"],
+      "height_name": ["20magl"],
       "height_station_masl": 17.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",

--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -3098,7 +3098,7 @@
     "ICOS": {
       "height": ["10m"],
       "height_name": ["10magl"],
-      "height_station_masl": 21.0,
+      "height_station_masl": 17.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
       "longitude": 1.12194
@@ -3106,7 +3106,7 @@
     "UCAM": {
       "height": ["10m"],
       "height_name": ["10magl"],
-      "height_station_masl": 21.0,
+      "height_station_masl": 17.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
       "longitude": 1.12194
@@ -3114,7 +3114,7 @@
     "UEA": {
       "height": ["10m"],
       "height_name": ["10magl"],
-      "height_station_masl": 21.0,
+      "height_station_masl": 17.0,
       "latitude": 52.95042,
       "long_name": "Weybourne Observatory, UK",
       "longitude": 1.12194


### PR DESCRIPTION
Unsure if this change is correct but I noticed a difference between WAO height details in ICOS and in our `site_info.json` file which means our height_site_masl and height may be the wrong way round.

 - `site_info.json` - "height_station_masl": 10.0; "height": ["21m"] - [https://github.com/openghg/supplementary_data/blob/main/openghg_defs/data/site_info.json#L3097](https://github.com/openghg/supplementary_data/blob/main/openghg_defs/data/site_info.json#L3097)
- ICOS station data - Elevation: "31 m"; Height above ground: 10m - [https://meta.icos-cp.eu/resources/stations/AS_WAO](https://meta.icos-cp.eu/resources/stations/AS_WAO) and [https://meta.icos-cp.eu/objects/dh1Xac2S-C0U24L96-HLDyPH](https://meta.icos-cp.eu/objects/dh1Xac2S-C0U24L96-HLDyPH).

~Also assuming 21m is correct for masl and elevation of 31m is 21masl + 10magl.~

From new details provided below the "height_station_masl" should be 17m (as of discussion at UEA in 11/2022).
