### PR TITLE
NPL: Adding height info of '17m' (from local attributes.json file)

### DIFF
--- a/openghg_defs/data/site_info.json
+++ b/openghg_defs/data/site_info.json
@@ -2062,13 +2062,14 @@
   },
   "NPL": {
     "LGHG": {
-      "height": ["NA"],
-      "height_name": ["NA"],
+      "height": ["17m"],
+      "height_name": ["17magl"],
       "height_station_masl": 0,
       "latitude": 51.4241,
       "long_name": "National Physical Laboratory",
       "longitude": -0.3487,
-      "status": "current"
+      "status": "current",
+      "comments": "Rooftop instrument at NPL campus in Teddington"
     }
   },
   "NWB": {


### PR DESCRIPTION
Current "height" for NPL (LGHG inlet at National Physical Laboratory) is listed as "NA" within the site_info.json file.

When processing in OpenGHG at the moment this is using a value from the `attributes.json` file instead which lists the inlet as "17m" rather than "NA".

Adding the "17m" to the `site_info.json` to ensure all inlet information is retrieve from one place.