### PR TITLE
Updated package to add loading functions, helpers functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
 *.egg-info/
-*/__pycache__/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,56 @@
 # openghg_defs
 
-The path to the overall data path and primary definition JSON files are accessible using:
+This repository contains the supplementary information / metadata used by the OpenGHG project.
 
-```python
-import openghg_defs
+## Installation
 
-data_path = openghg_defs.data_path
+We recommend you install `openghg_defs` in the same virtual environment as OpenGHG.
 
-species_info_file = openghg_defs.species_info_file
-site_info_file = openghg_defs.site_info_file
-domain_info_file = openghg_defs.domain_info_file
+To install `openghg_defs` using `pip` run
+
+```bash
+pip install openghg_defs
 ```
+
+## Usage
+
+The primary definition JSON files are accessible using either the loading functions
+
+- `load_site_info` - load site information dictionary
+- `load_domain_info` - load domain info dictionary
+- `load_species_info` - load species info dictionary
+
+For example
+
+```ipython3
+In [1]: import openghg_defs
+
+In [2]: species_info = openghg_defs.load_species_info()
+
+In [3]: species_info
+Out[3]:
+{'APO': {'alt': ['atmospheric_potential_oxygen'],
+  'group': 'Other',
+  'name': 'atmospheric_potential_oxygen',
+  'long_name': 'Atmospheric Potential Oxygen',
+  'mol_mass': 'None',
+  'print_string': 'APO',
+  'units': 'per meg'},
+ 'C2F6': {'alt': ['PFC-116', 'PFC116', 'hexafluoroethane'],
+  ...
+ ```
+
+You can also get the path of the file directly:
+
+```ipython3
+In [1]: from openghg_defs import get_datapath
+   ...:
+   ...: fpath = get_datapath(filename="site_info.json")
+
+In [2]: fpath
+Out[2]: PosixPath('/home/gareth/Documents/Devel/supplementary_data/openghg_defs/data/site_info.json')
+```
+
+### Deprecated functionality
+
+Version 0.0.1 of `openghg_defs` exposed paths to the JSON files storing the metadata. These are now deprecated and will be removed in a future version.

--- a/openghg_defs/__init__.py
+++ b/openghg_defs/__init__.py
@@ -1,10 +1,15 @@
-from pathlib import Path
+import warnings as _warnings
 
-module_root = Path(__file__).resolve().parent
+from ._load import load_domain_info, load_internal_json, load_site_info, load_species_info
+from ._paths import get_domain_path, get_datapath
 
-data_path: Path = module_root / "data"
+_warnings.warn(
+    message="Direct access to filepaths will be removed in the next release."
+    + " Please start using either the loader functions or get_datapath.",
+    category=DeprecationWarning,
+)
+del _warnings
 
-site_info_file: Path = data_path / "site_info.json"
-species_info_file: Path = data_path / "species_info.json"
-domain_info_file: Path = data_path / "domain_info.json"
-
+species_info_file = get_datapath(filename="species_info.json")
+site_info_file = get_datapath(filename="site_info.json")
+domain_info_file = get_datapath(filename="domain_info.json")

--- a/openghg_defs/_load.py
+++ b/openghg_defs/_load.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+
+def load_internal_json(filename: str) -> Dict:
+    """Load a JSON file from the data folder.
+
+    Returns:
+        dict: Dictionary from JSON
+    """
+    from openghg_defs import get_datapath
+
+    fpath = get_datapath(filename=filename)
+    return json.loads(fpath.read_text())
+
+
+def load_domain_info() -> Dict:
+    """Load the domain info from the data folder
+
+    Returns:
+        dict: Domain info
+    """
+    return load_internal_json(filename="domain_info.json")
+
+
+def load_site_info() -> Dict:
+    """Load the site info from the data folder
+
+    Returns:
+        dict: Site info
+    """
+    return load_internal_json(filename="site_info.json")
+
+
+def load_species_info() -> Dict:
+    """Load the species info from the data folder
+
+    Returns:
+        dict: Species info
+    """
+    return load_internal_json(filename="species_info.json")

--- a/openghg_defs/_paths.py
+++ b/openghg_defs/_paths.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+def get_domain_path(filename: str) -> Path:
+    """Get the filepath of a domain file
+
+    Args:
+        filename: Name of domain file
+    Returns:
+        Path: Filepath
+    """
+    return get_datapath().joinpath("domain", filename)
+
+def get_datapath(filename: str) -> Path:
+    """Return the full path to a file in the internal openghg_defs data folder
+
+    Args:
+        filename: Name of file
+    Returns:
+        Path: Filepath
+    """
+    return Path(__file__).parent.resolve().joinpath("data", filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "openghg_defs"
-version = "0.0.1"
+version = "0.1.0"
 description = "Supplementary definition data for OpenGHG"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 "Homepage" = "https://github.com/openghg/supplementary_data"


### PR DESCRIPTION
This updates the package to contain three loading functions
- `load_site_info`
- `load_domain_info`
- `load_species_info`
And some path helper functions
- `get_datapath` - get the path of the JSON you want to load
- `get_domain_path` - get the path of a file in the domain folder using its filename

It also bumps the version to 0.1.0 and updates the README to contain installation instructions and a couple of examples.
I've added a deprecation warning for the ACRG like use of the direct paths `species_info_file` etc.